### PR TITLE
ngrok LWRP

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,3 +20,10 @@ suites:
           kitchen-ci-test-vm:
             proto:
               http+https: 80
+  - name: lwrp
+    run_list:
+      - recipe[apt]
+      - recipe[fake]
+    attributes:
+      ngrok:
+        auth_token: Dtv-m6wlNK8DIzE8UB9u

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,7 +12,7 @@ suites:
   - name: default
     run_list:
       - recipe[apt]
-      - recipe[ngrok::default]
+      - recipe[ngrok]
     attributes:
       ngrok:
         auth_token: Dtv-m6wlNK8DIzE8UB9u

--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,6 @@
 source 'https://api.berkshelf.com'
 
 cookbook 'apt'
+cookbook 'fake', path: 'test/fixtures/cookbooks/fake'
 
 metadata

--- a/providers/tunnel.rb
+++ b/providers/tunnel.rb
@@ -1,0 +1,60 @@
+# Configures an ngrok tunnel.
+#
+# Provider:: tunnel
+# Cookbook: ngrok
+# Author:: Mike Juarez <mike@orionlabs.co>
+# Copyright:: Copyright 2015 OnBeep, Inc.
+# License:: Apache License, Version 2.0
+# Source:: https://github.com/onbeep-cookbooks/ngrok
+#
+
+
+require 'yaml'
+require 'json'
+
+def whyrun_supported?
+  true
+end
+
+action :create do
+  node.set['ngrok']['tunnels'][@tunnel_name] = @tunnel_config
+  render_ngrok_config()
+end
+
+action :delete do
+  if node['ngrok']['tunnels'][@tunnel_name]
+    node.set['ngrok']['tunnels'].tap { |tun| tun.delete(@tunnel_name) }
+  end
+  render_ngrok_config
+end
+
+def render_ngrok_config
+  ngrok_config = {
+    'auth_token' => node['ngrok']['auth_token'],
+    'tunnels' => node['ngrok']['tunnels']
+  }
+
+  hash = ngrok_config.to_hash
+  mutable_hash = JSON.parse(hash.dup.to_json)
+  ngrok_config = mutable_hash.to_yaml
+
+  file node['ngrok']['config_file'] do
+    content ngrok_config
+  end
+end
+
+def load_current_resource
+  @current_resource = Chef::Resource::NgrokTunnel.new(@new_resource.name)
+  @tunnel_name = new_resource.name
+  @tunnel_config = {}
+  @tunnel_config[:addr] = new_resource.addr if new_resource.addr
+  @tunnel_config[:auth] = new_resource.auth if new_resource.auth
+  @tunnel_config[:bind_tls] = new_resource.bind_tls if new_resource.bind_tls
+  @tunnel_config[:host_header] = new_resource.host_header if new_resource.host_header
+  @tunnel_config[:inspect] = new_resource.inspect unless new_resource.inspect.nil?
+  @tunnel_config[:proto] = new_resource.proto if new_resource.proto
+  @tunnel_config[:subdomain] = new_resource.subdomain if new_resource.subdomain
+  @tunnel_config[:crt] = new_resource.crt if new_resource.crt
+  @tunnel_config[:key] = new_resource.key if new_resource.key
+  @tunnel_config[:remote_addr] = new_resource.remote_addr if new_resource.remote_addr
+end

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -21,6 +21,10 @@ ngrok_config['inspect_addr'] = node['ngrok']['inspect_addr'] if node['ngrok']['i
 
 
 file node['ngrok']['config_file'] do
-  content ngrok_config.to_yaml
+  # horrible workaround for immutablehash to mutable hash
+  hash = ngrok_config.to_hash
+  mutable_hash = JSON.parse(hash.dup.to_json)
+  ngrok_config = mutable_hash.to_yaml
+  content ngrok_config
   notifies :restart, 'supervisor_service[ngrok]', :delayed
 end

--- a/resources/tunnel.rb
+++ b/resources/tunnel.rb
@@ -1,0 +1,30 @@
+# Configures an ngrok tunnel.
+#
+# Resources:: tunnel
+# Cookbook: ngrok
+# Author:: Mike Juarez <mike@orionlabs.co>
+# Copyright:: Copyright 2015 OnBeep, Inc.
+# License:: Apache License, Version 2.0
+# Source:: https://github.com/onbeep-cookbooks/ngrok
+#
+
+actions :create, :delete
+default_action :create
+
+attribute :name, :name_attribute => true, :kind_of => String, :required => true
+
+attribute :addr,         :kind_of => Fixnum, :required => true
+attribute :auth,         :kind_of => String
+attribute :bind_tls,     :kind_of => String
+attribute :host_header,  :kind_of => String
+attribute :inspect,      :kind_of => [ TrueClass, FalseClass ], :default => false
+attribute :proto,        :kind_of => String, :required => true
+attribute :subdomain,    :kind_of => String
+attribute :crt,          :kind_of => String
+attribute :key,          :kind_of => String
+attribute :remote_addr,  :kind_of => String
+
+def initalize(*args)
+  super
+  @action = :create
+end

--- a/test/fixtures/cookbooks/fake/metadata.rb
+++ b/test/fixtures/cookbooks/fake/metadata.rb
@@ -1,0 +1,4 @@
+name 'fake'
+version '1.0.0'
+
+depends 'ngrok'

--- a/test/fixtures/cookbooks/fake/recipes/default.rb
+++ b/test/fixtures/cookbooks/fake/recipes/default.rb
@@ -1,0 +1,16 @@
+include_recipe 'ngrok::zip_file'
+
+ngrok_tunnel "fake_cookbook_tunnel" do
+  addr 8080
+  auth "foo:biscuit"
+  bind_tls "both"
+  proto "http"
+  host_header "vagrant.local"
+  inspect false
+  subdomain "vagrant"
+  crt "example.crt"
+  key "example.key"
+  remote_addr "192.168.0.1:80"
+end
+
+include_recipe 'ngrok::service'

--- a/test/integration/lwrp/serverspec/localhost/ngrok_spec.rb
+++ b/test/integration/lwrp/serverspec/localhost/ngrok_spec.rb
@@ -1,0 +1,35 @@
+# Tests for ngrok Cookbook.
+#
+# Author:: Greg Albrecht <gba@onbeep.com>
+# Copyright:: Copyright 2014 OnBeep, Inc.
+# License:: Apache License, Version 2.0
+# Source:: https://github.com/onbeep-cookbooks/ngrok
+#
+
+
+require 'spec_helper'
+
+
+describe file('/usr/local/ngrok/ngrok') do
+  it { should be_file }
+  it { should be_executable }
+end
+
+describe command('/usr/local/ngrok/ngrok help') do
+  its(:stdout) { should match /Print help/ }
+end
+
+describe file('/etc/ngrok.conf') do
+  it { should be_file }
+  its(:content) { should match /fake_cookbook_tunnel/ }
+  its(:content) { should match /addr: 8080/ }
+  its(:content) { should match /auth: foo:biscuit/ }
+  its(:content) { should match /bind_tls: both/ }
+  its(:content) { should match /proto: http/ }
+  its(:content) { should match /host_header: vagrant.local/ }
+  its(:content) { should match /inspect: false/ }
+  its(:content) { should match /subdomain: vagrant/ }
+  its(:content) { should match /crt: example.crt/ }
+  its(:content) { should match /key: example.key/ }
+  its(:content) { should match /remote_addr: 192.168.0.1:80/ }
+end

--- a/test/integration/lwrp/serverspec/spec_helper.rb
+++ b/test/integration/lwrp/serverspec/spec_helper.rb
@@ -1,0 +1,12 @@
+require 'serverspec'
+
+set :backend, :exec
+
+RSpec.configure do |c|
+  if ENV['ASK_SUDO_PASSWORD']
+    require 'highline/import'
+    c.sudo_password = ask("Enter sudo password: ") { |q| q.echo = false }
+  else
+    c.sudo_password = ENV['SUDO_PASSWORD']
+  end
+end


### PR DESCRIPTION
* Addresses INFRA-413
* Adds in a new lightweight resource provider for ngrok tunnels
Example usage:
```
ngrok_tunnel "fake_cookbook_tunnel" do
  addr 8080
  auth "foo:biscuit"
  bind_tls "both"
  proto "http"
  host_header "vagrant.local"
  inspect false
  subdomain "vagrant"
  crt "example.crt"
  key "example.key"
  remote_addr "192.168.0.1:80"
end
```